### PR TITLE
Fixed typo on main page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -4,6 +4,4 @@ date: "2020-08-04"
 featuredImage: "./teamiste-jan2k23.webp"
 ---
 
-The Indian Society for Technical Education (ISTE) is the leading National Professional non-profit making Society for the Technical Education System in our country. The Students' Chapter NIT Hamirpur is the representative at NIT Hamirpur to promote such techincal culture in our college. We at NITH, conduct various events within the college and also participate in inter-college fests.
-
-
+The Indian Society for Technical Education (ISTE) is the leading National Professional non-profit making Society for the Technical Education System in our country. The Students' Chapter NIT Hamirpur is the representative at NIT Hamirpur to promote such technical culture in our college. We at NITH, conduct various events within the college and also participate in inter-college fests.


### PR DESCRIPTION
Fixed the spelling mistake of Technical on the main page in line 3 in the paragraph below the Team ISTE photo.