### PR TITLE
Homepage intro text stays in a fixed position. Also fixed image sizes…

### DIFF
--- a/public/home.css
+++ b/public/home.css
@@ -10,6 +10,9 @@
   font-size: 34px;
   font-weight: 600;
   min-width: 280px;
+  width: 500px;
+  margin: 0 auto;
+  text-align: start;
 }
 
 .animated-text span {

--- a/public/members.css
+++ b/public/members.css
@@ -45,6 +45,8 @@
   border-radius: 50%;
   box-shadow: 0 0 22px #3336;
   transition: 0.6s;
+  object-fit: contain;
+  background: whitesmoke;
 }
 
 .profile-card:hover img {


### PR DESCRIPTION
This change resolves #154: I have fixed the text position on the Homepage which allows it to stay in alignment at all times. I have also tinkered and fixed the team/member page so all image fit the screen correctly and has the same cosnsitency overall.

